### PR TITLE
Feature/cleanup slicer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> Result<(), SetLoggerError> {
         let mut out_file_name  = file_name.clone().to_owned();
         out_file_name.push_str("SLICED");
 
-        let file_out = fs::OpenOptions::new().create(true).append(true).open(&file_name ).expect("aaa");
+        let file_out = fs::OpenOptions::new().create(true).append(true).open(out_file_name ).expect("aaa");
 
         let saa: Box<SampleSliceAggregator> =Box::new(slicer::SampleSliceAggregator { file_out: file_out, fn_line_break: find_last_nl });
 


### PR DESCRIPTION
SlicerProcessor is now a trait. 
An SampleSliceProcessor implementation is included that simply adds slices to an output file expected NOT to diff.

pub trait SlicerProcessor {
    fn set_line_break_handler(&mut self, fn_line_break:FnLineBreak);
    fn get_line_break_handler(&self) -> FnLineBreak;

    fn process(&mut self,slices: Vec<&[u8]>) -> usize;
}
