### PR TITLE
feat: efficient chunked buffer slicing for multithreading

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           command: check
       - name: Cargo publish
-        run: cargo publish --token ${CRATES_TOKEN}
+        run: |
+          cd examples/full
+          cargo publish --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = [
     "Wilhelm Ågren <wilhelmagren98@gmail.com>",
 ]
 license = "MIT"
-version = "1.2.0"
+version = "1.3.0"
 readme = "README.md"
 categories = [
     "science",
@@ -26,16 +26,19 @@ categories = [
 keywords = [
     "arrow",
     "parquet",
+    "concurrency",
+    "data-engineering",
+    "ETL",
 ]
-description = "Efficiently evolve your old fixed-length data files into modern file formats. "
+description = "Efficiently evolve your old fixed-length data files into modern file formats."
 
 [workspace.dependencies]
-evolution-builder = { path = "crates/evolution-builder", version = "1.2.0" }
-evolution-common = { path = "crates/evolution-common", version = "1.2.0" }
-evolution-converter = { path = "crates/evolution-converter", version = "1.2.0" }
-evolution-mocker = { path = "crates/evolution-mocker", version = "1.2.0" }
-evolution-parser = { path = "crates/evolution-parser", version = "1.2.0" }
-evolution-schema = { path = "crates/evolution-schema", version = "1.2.0" }
-evolution-slicer = { path = "crates/evolution-slicer", version = "1.2.0" }
-evolution-target = { path = "crates/evolution-target", version = "1.2.0" }
-evolution-writer = { path = "crates/evolution-writer", version = "1.2.0" }
+evolution-builder = { path = "crates/evolution-builder", version = "1.3.0" }
+evolution-common = { path = "crates/evolution-common", version = "1.3.0" }
+evolution-converter = { path = "crates/evolution-converter", version = "1.3.0" }
+evolution-mocker = { path = "crates/evolution-mocker", version = "1.3.0" }
+evolution-parser = { path = "crates/evolution-parser", version = "1.3.0" }
+evolution-schema = { path = "crates/evolution-schema", version = "1.3.0" }
+evolution-slicer = { path = "crates/evolution-slicer", version = "1.3.0" }
+evolution-target = { path = "crates/evolution-target", version = "1.3.0" }
+evolution-writer = { path = "crates/evolution-writer", version = "1.3.0" }

--- a/crates/evolution-converter/Cargo.toml
+++ b/crates/evolution-converter/Cargo.toml
@@ -16,6 +16,7 @@ bench = false
 
 [dependencies]
 arrow = "51.0.0"
+bytesize = "1.3.0"
 crossbeam = "0.8.4"
 evolution-builder = { workspace = true }
 evolution-common = { workspace = true }

--- a/crates/evolution-slicer/src/slicer.rs
+++ b/crates/evolution-slicer/src/slicer.rs
@@ -145,13 +145,13 @@ impl FileSlicer {
 
     /// Try and evenly distribute the buffer into uniformly sized chunks for each worker thread.
     /// This function expects a [`Vec`] of usize tuples, representing the start and end byte
-    /// indices for each worke threads chunk. 
-    /// 
+    /// indices for each worker threads chunk.
+    ///
     /// # Note
     /// This function is optimized to spend as little time as possible looking for valid chunks, i.e.,
-    /// where there are line breaks, and will not look through the entire buffer. This can have an 
+    /// where there are line breaks, and will not look through the entire buffer. This can have an
     /// effect on the CPU cache hit-rate, however, this depends on the size of the buffer.
-    /// 
+    ///
     /// # Errors
     /// This function might return an error for the following reasons:
     /// * If the buffer was empty.

--- a/crates/evolution-slicer/src/slicer.rs
+++ b/crates/evolution-slicer/src/slicer.rs
@@ -22,10 +22,11 @@
 // SOFTWARE.
 //
 // File created: 2023-12-11
-// Last updated: 2024-05-31
+// Last updated: 2024-10-13
 //
 
 use evolution_common::error::{ExecutionError, Result};
+use evolution_common::NUM_BYTES_FOR_NEWLINE;
 use log::warn;
 
 use std::fs::{File, OpenOptions};
@@ -140,6 +141,57 @@ impl FileSlicer {
                 _ => Err(Box::new(e)),
             },
         }
+    }
+
+    /// Try and evenly distribute the buffer into uniformly sized chunks for each worker thread.
+    /// This function expects a [`Vec`] of usize tuples, representing the start and end byte
+    /// indices for each worke threads chunk. 
+    /// 
+    /// # Note
+    /// This function is optimized to spend as little time as possible looking for valid chunks, i.e.,
+    /// where there are line breaks, and will not look through the entire buffer. This can have an 
+    /// effect on the CPU cache hit-rate, however, this depends on the size of the buffer.
+    /// 
+    /// # Errors
+    /// This function might return an error for the following reasons:
+    /// * If the buffer was empty.
+    /// * If there were no line breaks in the buffer.
+    pub fn try_distribute_buffer_chunks_on_workers(
+        &self,
+        buffer: &[u8],
+        thread_workloads: &mut Vec<(usize, usize)>,
+    ) -> Result<()> {
+        let n_bytes_total: usize = buffer.len();
+        let n_worker_threads: usize = thread_workloads.capacity();
+
+        let n_bytes_per_thread: usize = n_bytes_total / n_worker_threads;
+        let n_bytes_remaining: usize = n_bytes_total - n_bytes_per_thread * n_worker_threads;
+
+        let mut prev_byte_idx: usize = 0;
+        for _ in 0..(n_worker_threads - 1) {
+            let next_byte_idx: usize = n_bytes_per_thread + prev_byte_idx;
+            thread_workloads.push((prev_byte_idx, next_byte_idx));
+            prev_byte_idx = next_byte_idx;
+        }
+
+        thread_workloads.push((
+            prev_byte_idx,
+            prev_byte_idx + n_bytes_per_thread + n_bytes_remaining,
+        ));
+
+        let mut n_bytes_to_offset_start: usize = 0;
+        for t_idx in 0..n_worker_threads {
+            let (mut start_byte_idx, mut end_byte_idx) = thread_workloads[t_idx];
+            start_byte_idx -= n_bytes_to_offset_start;
+            let n_bytes_to_offset_end: usize = (end_byte_idx - start_byte_idx)
+                - self.try_find_last_line_break(&buffer[start_byte_idx..end_byte_idx])?;
+            end_byte_idx -= n_bytes_to_offset_end;
+            thread_workloads[t_idx].0 = start_byte_idx;
+            thread_workloads[t_idx].1 = end_byte_idx;
+            n_bytes_to_offset_start = n_bytes_to_offset_end - NUM_BYTES_FOR_NEWLINE;
+        }
+
+        Ok(())
     }
 
     /// Read from the buffered reader into the provided buffer. This function reads


### PR DESCRIPTION
No longer reads entire buffer to find all line break characters, instead randomly picks n points (if we have n worker threads) then tries to find the previous line break and moves chunk offset to that byte idx.